### PR TITLE
Chunk upload fix for `multipart/form-data` form request.

### DIFF
--- a/src/FileUpload.vue
+++ b/src/FileUpload.vue
@@ -37,9 +37,7 @@ import ChunkUploadDefaultHandler from './chunk/ChunkUploadHandler'
 import InputFile from './InputFile.vue'
 
 const CHUNK_DEFAULT_OPTIONS = {
-  headers: {
-    'Content-Type': 'application/json'
-  },
+  headers: {},
   action: '',
   minSize: 1048576,
   maxActive: 3,

--- a/src/chunk/ChunkUploadHandler.js
+++ b/src/chunk/ChunkUploadHandler.js
@@ -168,6 +168,13 @@ export default class ChunkUploadHandler {
    */
   pause () {
     this.file.active = false
+    this.stopChunks()
+  }
+
+  /**
+   * Stops all the current chunks
+   */
+  stopChunks () {
     this.chunksUploading.forEach(chunk => {
       chunk.xhr.abort()
       chunk.active = false
@@ -208,7 +215,7 @@ export default class ChunkUploadHandler {
   start () {
     request({
       method: 'POST',
-      headers: Object.assign(this.headers, {
+      headers: Object.assign({}, this.headers, {
         'Content-Type': 'application/json'
       }),
       url: this.action,
@@ -275,9 +282,7 @@ export default class ChunkUploadHandler {
     this.updateFileProgress()
     chunk.xhr = createRequest({
       method: 'POST',
-      headers: Object.assign(this.headers, {
-        'Content-Type': 'multipart/form-data'
-      }),
+      headers: this.headers,
       url: this.action
     })
 
@@ -298,7 +303,7 @@ export default class ChunkUploadHandler {
         chunk.uploaded = true
       } else {
         if (chunk.retries-- <= 0) {
-          this.pause()
+          this.stopChunks()
           return this.reject('upload')
         }
       }
@@ -307,7 +312,7 @@ export default class ChunkUploadHandler {
     }).catch(() => {
       chunk.active = false
       if (chunk.retries-- <= 0) {
-        this.pause()
+        this.stopChunks()
         return this.reject('upload')
       }
 
@@ -324,7 +329,7 @@ export default class ChunkUploadHandler {
 
     request({
       method: 'POST',
-      headers: Object.assign(this.headers, {
+      headers: Object.assign({}, this.headers, {
         'Content-Type': 'application/json'
       }),
       url: this.action,


### PR DESCRIPTION
We forced the `header` for the chunk upload request to be `multipart/form-data` but the header must be set auotmatically when sending the `FormData`. This was causing the backend being unable to read parameters sent

Changed the way we stop the chunk process when the upload fails in `upload` phase. We no longer set the `file.active = false` since that would prevent the next file to start uploading